### PR TITLE
Adds SSL support when connecting to DB. Fixes #8

### DIFF
--- a/config/template_newrelic_plugin.yml
+++ b/config/template_newrelic_plugin.yml
@@ -31,7 +31,7 @@ agents:
     agent_name: "localhost:27017/mongodb"
     endpoint: "localhost"
     database: "sample-db"
-
+    ssl: false
     #
     #  If you are running MongoDB without authentication, please delete from now to the end
     #  of the file.

--- a/mongodb_agent.rb
+++ b/mongodb_agent.rb
@@ -10,7 +10,7 @@ module NewRelic::MongodbAgent
 
   class Agent < NewRelic::Plugin::Agent::Base
     agent_guid "com.mongohq.mongo-agent"
-    agent_config_options :endpoint, :username, :password, :database, :port, :agent_name
+    agent_config_options :endpoint, :username, :password, :database, :port, :agent_name, :ssl
     agent_human_labels("MongoDB") { "#{agent_name}" }
     agent_version '2.4.4-3'
 
@@ -84,7 +84,7 @@ module NewRelic::MongodbAgent
 
     def client
       @client ||= begin
-                    client = MongoClient.new(endpoint, port.to_i, :slave_ok => true)
+                    client = MongoClient.new(endpoint, port.to_i, :slave_ok => true, :ssl => ssl || false)
 
                     unless username.nil?
                       client.db("admin").authenticate(username, password)


### PR DESCRIPTION
This should fix the SSL issue just specify `ssl: true` in the config file. I don't have an SSL instance of mongodb to test this against but according to the mongodb docs this is all that is required to connect to an SSL instance.
